### PR TITLE
Fix pouchdb-nightly dependency label

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "angular": "~1.2.3",
-    "pouchdb-nightly": "http://download.pouchdb.com/pouchdb-nightly.min.js"
+    "pouchdb": "2.0"
   },
   "devDependencies": {
     "angular-mocks": "~1.2.3"


### PR DESCRIPTION
Removed the unnecessary '.min.js' from the end of the pouchdb-nightly dependency label because it confuses grunt and other ci tools. See issue #9 for details.
