### PR TITLE
Small fix for successful minification.

### DIFF
--- a/angular-pouchdb.coffee
+++ b/angular-pouchdb.coffee
@@ -60,7 +60,7 @@ pouchdb.provider 'pouchdb', ->
   withAllDbsEnabled: ->
     PouchDB.enableAllDbs = true
 
-  $get: ($q, $rootScope) ->
+  $get: ['$q', '$rootScope', ($q, $rootScope) ->
 
     qify = (fn) ->
       () ->
@@ -103,7 +103,8 @@ pouchdb.provider 'pouchdb', ->
         from: (remote, options) -> db.replicate.from(remote, options)
         sync: (remote, options) -> db.replicate.sync(remote, options)
       destroy: qify db.destroy.bind(db)
-
+  ]
+  
 # pouch-repeat="name in collection"
 pouchdb.directive 'pouchRepeat',
   ($parse, $animate) ->

--- a/angular-pouchdb.js
+++ b/angular-pouchdb.js
@@ -73,72 +73,74 @@ THE SOFTWARE.
       withAllDbsEnabled: function() {
         return PouchDB.enableAllDbs = true;
       },
-      $get: function($q, $rootScope) {
-        var qify;
-        qify = function(fn) {
-          return function() {
-            var args, callback, deferred;
-            deferred = $q.defer();
-            callback = function(err, res) {
-              return $rootScope.$apply(function() {
-                if (err) {
-                  return deferred.reject(err);
-                } else {
-                  return deferred.resolve(res);
-                }
-              });
+      $get: [
+        '$q', '$rootScope', function($q, $rootScope) {
+          var qify;
+          qify = function(fn) {
+            return function() {
+              var args, callback, deferred;
+              deferred = $q.defer();
+              callback = function(err, res) {
+                return $rootScope.$apply(function() {
+                  if (err) {
+                    return deferred.reject(err);
+                  } else {
+                    return deferred.resolve(res);
+                  }
+                });
+              };
+              args = arguments != null ? slice.call(arguments) : [];
+              args.push(callback);
+              fn.apply(this, args);
+              return deferred.promise;
             };
-            args = arguments != null ? slice.call(arguments) : [];
-            args.push(callback);
-            fn.apply(this, args);
-            return deferred.promise;
           };
-        };
-        return {
-          create: function(name, options) {
-            var db;
-            db = new PouchDB(name, options);
-            return {
-              id: db.id,
-              put: qify(db.put.bind(db)),
-              post: qify(db.post.bind(db)),
-              get: qify(db.get.bind(db)),
-              remove: qify(db.remove.bind(db)),
-              bulkDocs: qify(db.bulkDocs.bind(db)),
-              allDocs: qify(db.allDocs.bind(db)),
-              changes: function(options) {
-                var clone;
-                clone = angular.copy(options);
-                clone.onChange = function(change) {
-                  return $rootScope.$apply(function() {
-                    return options.onChange(change);
-                  });
-                };
-                return db.changes(clone);
-              },
-              putAttachment: qify(db.putAttachment.bind(db)),
-              getAttachment: qify(db.getAttachment.bind(db)),
-              removeAttachment: qify(db.removeAttachment.bind(db)),
-              query: qify(db.query.bind(db)),
-              info: qify(db.info.bind(db)),
-              compact: qify(db.compact.bind(db)),
-              revsDiff: qify(db.revsDiff.bind(db)),
-              replicate: {
-                to: function(remote, options) {
-                  return db.replicate.to(remote, options);
+          return {
+            create: function(name, options) {
+              var db;
+              db = new PouchDB(name, options);
+              return {
+                id: db.id,
+                put: qify(db.put.bind(db)),
+                post: qify(db.post.bind(db)),
+                get: qify(db.get.bind(db)),
+                remove: qify(db.remove.bind(db)),
+                bulkDocs: qify(db.bulkDocs.bind(db)),
+                allDocs: qify(db.allDocs.bind(db)),
+                changes: function(options) {
+                  var clone;
+                  clone = angular.copy(options);
+                  clone.onChange = function(change) {
+                    return $rootScope.$apply(function() {
+                      return options.onChange(change);
+                    });
+                  };
+                  return db.changes(clone);
                 },
-                from: function(remote, options) {
-                  return db.replicate.from(remote, options);
+                putAttachment: qify(db.putAttachment.bind(db)),
+                getAttachment: qify(db.getAttachment.bind(db)),
+                removeAttachment: qify(db.removeAttachment.bind(db)),
+                query: qify(db.query.bind(db)),
+                info: qify(db.info.bind(db)),
+                compact: qify(db.compact.bind(db)),
+                revsDiff: qify(db.revsDiff.bind(db)),
+                replicate: {
+                  to: function(remote, options) {
+                    return db.replicate.to(remote, options);
+                  },
+                  from: function(remote, options) {
+                    return db.replicate.from(remote, options);
+                  },
+                  sync: function(remote, options) {
+                    return db.replicate.sync(remote, options);
+                  }
                 },
-                sync: function(remote, options) {
-                  return db.replicate.sync(remote, options);
-                }
-              },
-              destroy: qify(db.destroy.bind(db))
-            };
-          }
-        };
-      }
+                destroy: qify(db.destroy.bind(db))
+              };
+            }
+          };
+        }
+      ]
     };
   });
 

--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "angular": "~1.2.3",
-    "pouchdb": "/Users/wilfred/workspace/pouchdb/dist/pouchdb-nightly.js"
+    "pouchdb": "~2.0.1"
   },
   "devDependencies": {
     "angular-mocks": "~1.2.3"

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -11,7 +11,7 @@ module.exports = function(config) {
     files: [
       'bower_components/angular/angular.js',
       'bower_components/angular-mocks/angular-mocks.js',
-      'bower_components/pouchdb/index.js',
+      'bower_components/pouchdb/dist/pouchdb-nightly.js',
       'angular-pouchdb.js',
       'test/**/*-spec.js'
     ],
@@ -42,7 +42,7 @@ module.exports = function(config) {
 
     // level of logging
     // possible values: LOG_DISABLE || LOG_ERROR || LOG_WARN || LOG_INFO || LOG_DEBUG
-    logLevel: LOG_INFO,
+    logLevel: config.LOG_INFO,
 
 
     // enable / disable watching file and executing tests whenever any file changes


### PR DESCRIPTION
When `angular-pouchdb.js` is minified, the params to `$get` can get munged. Using the array style definition prevents this.
