### PR TITLE
Allow object.properties as collection in pouch-repeat

### DIFF
--- a/angular-pouchdb.coffee
+++ b/angular-pouchdb.coffee
@@ -116,7 +116,7 @@ pouchdb.directive 'pouchRepeat',
         top = angular.element(document.createElement('div'))
         parent.append(top)
         [cursor, collection, sort] =
-          /^\s*([a-zA-Z0-9]+)\s*in\s*([a-zA-Z0-9]+)\s*(?:order by\s*([a-zA-Z0-9\.,]+))?$/.exec($attr.pouchRepeat).splice(1)
+          /^\s*([a-zA-Z0-9]+)\s*in\s*([a-zA-Z0-9\.]+)\s*(?:order by\s*([a-zA-Z0-9\.,]+))?$/.exec($attr.pouchRepeat).splice(1)
 
         # The blocks managed by this directive.
         blocks = []


### PR DESCRIPTION
https://github.com/wspringer/angular-pouchdb/issues/13#issuecomment-41565975
